### PR TITLE
TECH-4845: replace hobo fields with declare schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Inspired by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 Note: this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.3.0] - Unreleased
+## [1.3.1] - Unreleased
 ### Changed
 - Replace `hobo_fields` with `declare_schema`.
 - Update :text/:string in schemas.
@@ -26,5 +26,6 @@ Note: this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0
 - Get rubocop running again.
 - Clean up Rakefile.
 
+[1.3.1]: https://github.com/Invoca/git_models/compare/v1.2.0...v1.3.1
 [1.2.0]: https://github.com/Invoca/git_models/compare/v1.1.1...v1.2.0
 [1.1.1]: https://github.com/Invoca/git_models/compare/v1.1.0...v1.1.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Inspired by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 Note: this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.0] - Unreleased
+### Changed
+- Replace `hobo_fields` with `declare_schema`.
+
 ## [1.2.0] - 2020-07-13
 ### Added
 - Add support for Rails 5 and 6.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Note: this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0
 ## [1.3.0] - Unreleased
 ### Changed
 - Replace `hobo_fields` with `declare_schema`.
+- Update :text/:string in schemas.
 
 ## [1.2.0] - 2020-07-13
 ### Added

--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,6 @@ gem 'climate_control'
 gem 'coveralls', require: false
 gem 'database_cleaner'
 gem 'git_lib',      '~> 1.2', git: 'https://github.com/Invoca/git_lib.git', ref: 'a4a4b46ba00d85df4ca907c960ddf92a85a8c169'
-gem 'hobo_fields',  '~> 3.0', git: 'https://github.com/Invoca/hobo_fields.git', ref: 'e9623e9c3aa98a4822ef61d1f1e87d0ff8001ffc'
 gem 'pry'
 gem 'rails',        '>= 4.2'
 gem 'rake'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,20 +6,12 @@ GIT
     git_lib (1.2.0)
       activesupport (>= 4.2, < 7)
 
-GIT
-  remote: https://github.com/Invoca/hobo_fields.git
-  revision: e9623e9c3aa98a4822ef61d1f1e87d0ff8001ffc
-  ref: e9623e9c3aa98a4822ef61d1f1e87d0ff8001ffc
-  specs:
-    hobo_fields (3.0.0)
-      invoca-utils (~> 0.4)
-
 PATH
   remote: .
   specs:
     git_models (1.2.0)
+      declare_schema (~> 0.1)
       git_lib (~> 1.2)
-      hobo_fields (~> 3.0)
       rails (>= 4.2, < 7)
 
 GEM
@@ -87,6 +79,8 @@ GEM
       tins (~> 1.6)
     crass (1.0.6)
     database_cleaner (1.8.5)
+    declare_schema (0.1.1)
+      rails (>= 4.2)
     diff-lcs (1.3)
     docile (1.3.2)
     erubi (1.9.0)
@@ -94,7 +88,6 @@ GEM
       activesupport (>= 4.2.0)
     i18n (1.8.3)
       concurrent-ruby (~> 1.0)
-    invoca-utils (0.4.1)
     json (2.3.0)
     loofah (2.6.0)
       crass (~> 1.0.2)
@@ -220,7 +213,6 @@ DEPENDENCIES
   database_cleaner
   git_lib (~> 1.2)!
   git_models!
-  hobo_fields (~> 3.0)!
   pry
   rails (>= 4.2)
   rake

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ GIT
 PATH
   remote: .
   specs:
-    git_models (1.2.0)
+    git_models (1.3.0)
       declare_schema (~> 0.1)
       git_lib (~> 1.2)
       rails (>= 4.2, < 7)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ GIT
 PATH
   remote: .
   specs:
-    git_models (1.3.0)
+    git_models (1.3.1)
       declare_schema (~> 0.2)
       git_lib (~> 1.2)
       rails (>= 4.2, < 7)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,7 +10,7 @@ PATH
   remote: .
   specs:
     git_models (1.3.0)
-      declare_schema (~> 0.1)
+      declare_schema (~> 0.2)
       git_lib (~> 1.2)
       rails (>= 4.2, < 7)
 
@@ -79,7 +79,7 @@ GEM
       tins (~> 1.6)
     crass (1.0.6)
     database_cleaner (1.8.5)
-    declare_schema (0.1.1)
+    declare_schema (0.2.0)
       rails (>= 4.2)
     diff-lcs (1.3)
     docile (1.3.2)

--- a/Rakefile
+++ b/Rakefile
@@ -10,11 +10,8 @@ RSpec::Core::RakeTask.new
 Coveralls::RakeTask.new
 Bundler::Audit::Task.new
 
-desc "db"
 namespace :db do
-  desc "test"
   namespace :test do
-    desc "prepare"
     task :prepare do
       system <<~EOS
         set -ex

--- a/app/models/concerns/branch.rb
+++ b/app/models/concerns/branch.rb
@@ -6,8 +6,9 @@ module GitModels
 
     included do
       fields do
-        git_updated_at :datetime, null: false
-        name :text, limit: 1024, null: false
+        git_updated_at  :datetime, null: false
+        name            :string, limit: 1024, null: false
+
         timestamps
       end
 

--- a/app/models/concerns/branch.rb
+++ b/app/models/concerns/branch.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'hobo_fields'
-
 module GitModels
   module Branch
     extend ActiveSupport::Concern

--- a/app/models/concerns/commit.rb
+++ b/app/models/concerns/commit.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'hobo_fields'
+require 'declare_schema'
 
 module GitModels
   module Commit

--- a/app/models/concerns/commit.rb
+++ b/app/models/concerns/commit.rb
@@ -8,8 +8,9 @@ module GitModels
 
     included do
       fields do
-        sha :text, limit: 40, null: false
-        message :text, limit: 1024, null: false
+        sha     :string, limit: 255, null: false
+        message :text, null: false
+
         timestamps
       end
 

--- a/app/models/concerns/repository.rb
+++ b/app/models/concerns/repository.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'hobo_fields'
+require 'declare_schema'
 
 module GitModels
   module Repository

--- a/app/models/concerns/repository.rb
+++ b/app/models/concerns/repository.rb
@@ -8,7 +8,8 @@ module GitModels
 
     included do
       fields do
-        name :text, limit: 1024, null: false
+        name    :string, limit: 255, null: false
+
         timestamps
       end
 

--- a/app/models/concerns/user.rb
+++ b/app/models/concerns/user.rb
@@ -8,8 +8,9 @@ module GitModels
 
     included do
       fields do
-        name :text, limit: 255, null: false
-        email :text, limit: 255, null: false
+        name    :string, limit: 255, null: false
+        email   :string, limit: 255, null: false
+
         timestamps
       end
 

--- a/app/models/concerns/user.rb
+++ b/app/models/concerns/user.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'hobo_fields'
+require 'declare_schema'
 
 module GitModels
   module User

--- a/gemfiles/rails_4.gemfile
+++ b/gemfiles/rails_4.gemfile
@@ -8,10 +8,9 @@ gem "bundler-audit", require: false
 gem "climate_control"
 gem "coveralls", require: false
 gem "database_cleaner"
-gem "git_lib", "~> 1.2", git: "git@github.com:Invoca/git_lib", ref: "785505fd4d55eb6968a75cdb546365d935d8655b"
-gem "hobo_fields", "~> 3.0", git: "git@github.com:Invoca/hobo_fields", ref: "e9623e9c3aa98a4822ef61d1f1e87d0ff8001ffc"
+gem "git_lib", "~> 1.2", git: "https://github.com/Invoca/git_lib.git", ref: "a4a4b46ba00d85df4ca907c960ddf92a85a8c169"
 gem "pry"
-gem "rails", ">= 4.2"
+gem "rails", "~> 4.2"
 gem "rake"
 gem "rspec", "~> 3.5"
 gem "rspec-core"
@@ -21,6 +20,5 @@ gem "rubocop", "~> 0.45.0", require: false
 gem "rubocop-rspec", require: false
 gem "sqlite3", "~> 1.3.6"
 gem "tzinfo-data"
-gem "activesupport", "~> 4.2"
 
 gemspec path: "../"

--- a/gemfiles/rails_5.gemfile
+++ b/gemfiles/rails_5.gemfile
@@ -8,10 +8,9 @@ gem "bundler-audit", require: false
 gem "climate_control"
 gem "coveralls", require: false
 gem "database_cleaner"
-gem "git_lib", "~> 1.2", git: "git@github.com:Invoca/git_lib", ref: "785505fd4d55eb6968a75cdb546365d935d8655b"
-gem "hobo_fields", "~> 3.0", git: "git@github.com:Invoca/hobo_fields", ref: "e9623e9c3aa98a4822ef61d1f1e87d0ff8001ffc"
+gem "git_lib", "~> 1.2", git: "https://github.com/Invoca/git_lib.git", ref: "a4a4b46ba00d85df4ca907c960ddf92a85a8c169"
 gem "pry"
-gem "rails", ">= 4.2"
+gem "rails", "~> 5.2"
 gem "rake"
 gem "rspec", "~> 3.5"
 gem "rspec-core"
@@ -21,6 +20,5 @@ gem "rubocop", "~> 0.45.0", require: false
 gem "rubocop-rspec", require: false
 gem "sqlite3", "~> 1.3.6"
 gem "tzinfo-data"
-gem "activesupport", "~> 5.2"
 
 gemspec path: "../"

--- a/gemfiles/rails_6.gemfile
+++ b/gemfiles/rails_6.gemfile
@@ -8,10 +8,9 @@ gem "bundler-audit", require: false
 gem "climate_control"
 gem "coveralls", require: false
 gem "database_cleaner"
-gem "git_lib", "~> 1.2", git: "git@github.com:Invoca/git_lib", ref: "785505fd4d55eb6968a75cdb546365d935d8655b"
-gem "hobo_fields", "~> 3.0", git: "git@github.com:Invoca/hobo_fields", ref: "e9623e9c3aa98a4822ef61d1f1e87d0ff8001ffc"
+gem "git_lib", "~> 1.2", git: "https://github.com/Invoca/git_lib.git", ref: "a4a4b46ba00d85df4ca907c960ddf92a85a8c169"
 gem "pry"
-gem "rails", ">= 4.2"
+gem "rails", "~> 6.0"
 gem "rake"
 gem "rspec", "~> 3.5"
 gem "rspec-core"
@@ -21,6 +20,5 @@ gem "rubocop", "~> 0.45.0", require: false
 gem "rubocop-rspec", require: false
 gem "sqlite3", "~> 1.4"
 gem "tzinfo-data"
-gem "activesupport", "~> 6.0"
 
 gemspec path: "../"

--- a/git_models.gemspec
+++ b/git_models.gemspec
@@ -22,6 +22,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['app', 'lib']
 
   spec.add_dependency 'rails',        '>= 4.2', '< 7'
-  spec.add_dependency 'hobo_fields',  '~> 3.0'
+  spec.add_dependency 'declare_schema', '~> 0.1'
   spec.add_dependency 'git_lib',      '~> 1.2'
 end

--- a/git_models.gemspec
+++ b/git_models.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['app', 'lib']
 
-  spec.add_dependency 'declare_schema', '~> 0.1'
+  spec.add_dependency 'declare_schema', '~> 0.2'
   spec.add_dependency 'git_lib',      '~> 1.2'
   spec.add_dependency 'rails',        '>= 4.2', '< 7'
 end

--- a/git_models.gemspec
+++ b/git_models.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['app', 'lib']
 
-  spec.add_dependency 'rails',        '>= 4.2', '< 7'
   spec.add_dependency 'declare_schema', '~> 0.1'
   spec.add_dependency 'git_lib',      '~> 1.2'
+  spec.add_dependency 'rails',        '>= 4.2', '< 7'
 end

--- a/lib/git_models/version.rb
+++ b/lib/git_models/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module GitModels
-  VERSION = '1.3.0'
+  VERSION = '1.3.1'
 end

--- a/lib/git_models/version.rb
+++ b/lib/git_models/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module GitModels
-  VERSION = '1.2.0'
+  VERSION = '1.3.0'
 end


### PR DESCRIPTION
### Changed
- Replace `hobo_fields` with `declare_schema`.
- Update :text/:string in schemas to match the recent schema changes in `pre_deploy_checker`.
- Bump version to 1.3.1 (1.3.0 was yanked).
